### PR TITLE
feat: implement Settings screen with About and Help navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+copilot-instructions.md

--- a/app/(drawer)/(tabs)/settings/_layout.tsx
+++ b/app/(drawer)/(tabs)/settings/_layout.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+import { useTheme } from '../../../../src/contexts/ThemeContext';
+
+export default function SettingsLayout() {
+  const { colors } = useTheme();
+
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: colors.background,
+        },
+        headerTintColor: colors.text,
+        headerTitleStyle: {
+          fontWeight: 'bold',
+        },
+      }}
+    >
+      <Stack.Screen
+        name="index"
+        options={{
+          title: 'Configurações',
+        }}
+      />
+      <Stack.Screen
+        name="help"
+        options={{
+          title: 'Ajuda e Suporte',
+        }}
+      />
+      <Stack.Screen
+        name="about"
+        options={{
+          title: 'Sobre o App',
+        }}
+      />
+    </Stack>
+  );
+}

--- a/app/(drawer)/(tabs)/settings/about.tsx
+++ b/app/(drawer)/(tabs)/settings/about.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AboutScreen } from '../../../../src/components/screens/About';
+
+export default function About() {
+  return <AboutScreen />;
+}

--- a/app/(drawer)/(tabs)/settings/help.tsx
+++ b/app/(drawer)/(tabs)/settings/help.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { HelpScreen } from '../../../../src/components/screens/Help';
+
+export default function Help() {
+  return <HelpScreen />;
+}

--- a/app/(drawer)/(tabs)/settings/index.tsx
+++ b/app/(drawer)/(tabs)/settings/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { SettingsScreen } from '../../../../src/components/screens/Settings';
+
+export default function Settings() {
+  return <SettingsScreen />;
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -2,6 +2,19 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
+// Reduzir imports de ícones
+config.resolver.alias = {
+  '@expo/vector-icons': '@expo/vector-icons/Ionicons',
+};
+
+// Excluir arquivos desnecessários
+config.resolver.blockList = [
+  /.*\.md$/,
+  /.*\.test\.(js|jsx|ts|tsx)$/,
+  /.*\.spec\.(js|jsx|ts|tsx)$/,
+  /.*\/__tests__\/.*/,
+];
+
 // Adicionar extensões SVG
 config.transformer.babelTransformerPath = require.resolve('react-native-svg-transformer');
 config.resolver.assetExts = config.resolver.assetExts.filter(ext => ext !== 'svg');

--- a/src/components/atoms/ThemeDropdown/index.tsx
+++ b/src/components/atoms/ThemeDropdown/index.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, Modal, FlatList } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme, ThemeMode } from '../../../contexts/ThemeContext';
+import { createThemeDropdownStyles } from './styles';
+
+interface ThemeOption {
+  value: ThemeMode;
+  label: string;
+  icon: string;
+}
+
+const themeOptions: ThemeOption[] = [
+  { value: 'light', label: 'Claro', icon: 'sunny' },
+  { value: 'dark', label: 'Escuro', icon: 'moon' },
+  { value: 'system', label: 'Sistema', icon: 'phone-portrait' },
+];
+
+export const ThemeDropdown = () => {
+  const { themeMode, setThemeMode, colors } = useTheme();
+  const [isVisible, setIsVisible] = useState(false);
+  const styles = createThemeDropdownStyles(colors);
+
+  const selectedOption = themeOptions.find(option => option.value === themeMode);
+
+  const handleSelect = (mode: ThemeMode) => {
+    setThemeMode(mode);
+    setIsVisible(false);
+  };
+
+  const renderOption = ({ item }: { item: ThemeOption }) => (
+    <TouchableOpacity
+      style={[
+        styles.option,
+        item.value === themeMode && styles.selectedOption
+      ]}
+      onPress={() => handleSelect(item.value)}
+    >
+      <Ionicons 
+        name={item.icon as any} 
+        size={20} 
+        color={item.value === themeMode ? '#fff' : colors.text} 
+      />
+      <Text style={[
+        styles.optionText,
+        item.value === themeMode && styles.selectedOptionText
+      ]}>
+        {item.label}
+      </Text>
+      {item.value === themeMode && (
+        <Ionicons name="checkmark" size={20} color="#fff" />
+      )}
+    </TouchableOpacity>
+  );
+
+  return (
+    <>
+      <TouchableOpacity 
+        style={styles.dropdown}
+        onPress={() => setIsVisible(true)}
+      >
+        <View style={styles.selectedValue}>
+          <Ionicons 
+            name={selectedOption?.icon as any} 
+            size={18} 
+            color={colors.text} 
+          />
+          <Text style={styles.selectedText}>
+            {selectedOption?.label}
+          </Text>
+        </View>
+        <Ionicons name="chevron-down" size={18} color={colors.textSecondary} />
+      </TouchableOpacity>
+
+      <Modal
+        visible={isVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setIsVisible(false)}
+      >
+        <TouchableOpacity 
+          style={styles.overlay}
+          onPress={() => setIsVisible(false)}
+        >
+          <View style={styles.modal}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Escolher Tema</Text>
+            </View>
+            <FlatList
+              data={themeOptions}
+              keyExtractor={(item) => item.value}
+              renderItem={renderOption}
+              showsVerticalScrollIndicator={false}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/atoms/ThemeDropdown/styles.ts
+++ b/src/components/atoms/ThemeDropdown/styles.ts
@@ -1,0 +1,70 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '../../../constants/theme';
+
+export const createThemeDropdownStyles = (themeColors: any) => StyleSheet.create({
+  dropdown: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: themeColors.surface,
+    padding: 8,
+    borderBottomWidth: 1,
+    borderColor: themeColors.border,
+  },
+  selectedValue: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  selectedText: {
+    fontSize: 14,
+    color: themeColors.text,
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    backgroundColor: themeColors.surface,
+    borderRadius: 12,
+    margin: 20,
+    width: '80%',
+    maxHeight: '50%',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    overflow: 'hidden',
+  },
+  modalHeader: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: themeColors.border,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: themeColors.text,
+    textAlign: 'center',
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    gap: 12,
+  },
+  selectedOption: {
+    backgroundColor: colors.primary[500],
+  },
+  optionText: {
+    flex: 1,
+    fontSize: 16,
+    color: themeColors.text,
+  },
+  selectedOptionText: {
+    color: '#fff',
+  },
+});

--- a/src/components/molecules/FAQItem/index.tsx
+++ b/src/components/molecules/FAQItem/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Text } from '@/components/atoms/Text';
+import { useTheme } from '@/contexts/ThemeContext';
+import { createFAQItemStyles } from './styles';
+
+interface FAQItemProps {
+  question: string;
+  answer: string;
+}
+
+export const FAQItem = ({ question, answer }: FAQItemProps) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const { colors } = useTheme();
+  const styles = createFAQItemStyles(colors);
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity 
+        style={styles.header}
+        onPress={() => setIsExpanded(!isExpanded)}
+      >
+        <Text variant="subtitle" style={styles.question}>
+          {question}
+        </Text>
+        <Ionicons 
+          name={isExpanded ? "chevron-up" : "chevron-down"} 
+          size={20} 
+          color={colors.textSecondary} 
+        />
+      </TouchableOpacity>
+      {isExpanded && (
+        <View style={styles.answer}>
+          <Text variant="body" color="textSecondary" style={styles.answerText}>
+            {answer}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+};

--- a/src/components/molecules/FAQItem/styles.ts
+++ b/src/components/molecules/FAQItem/styles.ts
@@ -1,0 +1,28 @@
+import { StyleSheet } from 'react-native';
+import { colors as themeColors } from '../../../constants/theme';
+
+export const createFAQItemStyles = (colors: typeof themeColors.theme.light) => StyleSheet.create({
+  container: {
+    backgroundColor: colors.surface,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    minHeight: 56,
+  },
+  question: {
+    flex: 1,
+    marginRight: 12,
+    fontWeight: '500',
+  },
+  answer: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  answerText: {
+    lineHeight: 22,
+  },
+});

--- a/src/components/molecules/SettingsItem/index.tsx
+++ b/src/components/molecules/SettingsItem/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Text } from '../../atoms/Text';
+import { useTheme } from '../../../contexts/ThemeContext';
+import { createSettingsItemStyles } from './styles';
+import { colors } from '@/constants/theme';
+
+interface SettingsItemProps {
+  title: string;
+  subtitle: string;
+  icon: string;
+  onPress?: () => void;
+  disabled?: boolean;
+  children?: React.ReactNode;
+  showChevron?: boolean;
+}
+
+export const SettingsItem = ({ 
+  title, 
+  subtitle, 
+  icon, 
+  onPress, 
+  disabled = false,
+  children,
+  showChevron = true
+}: SettingsItemProps) => {
+  const { colors: themeColors } = useTheme();
+  const styles = createSettingsItemStyles(themeColors);
+
+  const Component = onPress ? TouchableOpacity : View;
+
+  return (
+    <Component 
+      style={[styles.container, disabled && styles.disabled]}
+      onPress={!disabled ? onPress : undefined}
+      disabled={disabled}
+    >
+      <View style={styles.iconContainer}>
+        <Ionicons 
+          name={icon as any} 
+          size={20} 
+          color={disabled ? themeColors.textSecondary : colors.primary[500]} 
+        />
+      </View>
+      
+      <View style={styles.content}>
+        <Text variant="subtitle" color={disabled ? 'textSecondary' : 'text'}>
+          {title}
+        </Text>
+        <Text variant="caption" color="textSecondary">
+          {subtitle}
+        </Text>
+        {children}
+      </View>
+      
+      {showChevron && !children && (
+        <Ionicons 
+          name="chevron-forward" 
+          size={20} 
+          color={themeColors.textSecondary} 
+        />
+      )}
+    </Component>
+  );
+};

--- a/src/components/molecules/SettingsItem/styles.ts
+++ b/src/components/molecules/SettingsItem/styles.ts
@@ -1,0 +1,39 @@
+import { StyleSheet } from 'react-native';
+import { colors as themeColors } from '@/constants/theme';
+
+export const createSettingsItemStyles = (colors: typeof themeColors.theme.light) => StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
+    borderRadius: 8,
+    marginHorizontal: 16,
+
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.2,
+    shadowRadius: 1.41,
+    elevation: 1,
+  },
+  disabled: {
+    opacity: 0.7,
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.surfaceAlt,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  content: {
+    flex: 1,
+  },
+});

--- a/src/components/screens/About/index.tsx
+++ b/src/components/screens/About/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { ScrollView, View, Image } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Text } from '@/components/atoms/Text';
+import { createAboutScreenStyles } from './styles';
+
+export const AboutScreen = () => {
+  const { colors } = useTheme();
+  const styles = createAboutScreenStyles(colors);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Versão
+        </Text>
+        <Text variant="body" color="textSecondary" style={styles.version}>
+          1.0.0
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Sobre o aplicativo
+        </Text>
+        <Text variant="body" color="textSecondary" style={styles.description}>
+          O PoupeAI é um aplicativo de gestão financeira pessoal que utiliza inteligência artificial para ajudar você a controlar suas finanças, criar orçamentos inteligentes e alcançar seus objetivos financeiros.
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Desenvolvido por
+        </Text>
+        <Text variant="body" color="textSecondary" style={styles.developer}>
+          <View style={styles.techList}>
+          <Text variant="body" color="textSecondary" style={styles.techItem}>
+            • Eudivan de Melo
+          </Text>
+          <Text variant="body" color="textSecondary" style={styles.techItem}>
+            • Erisvaldo Balbino
+          </Text>
+          <Text variant="body" color="textSecondary" style={styles.techItem}>
+            • Francisco Paulino
+          </Text>
+        </View>
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Licença
+        </Text>
+        <Text variant="body" color="textSecondary" style={styles.license}>
+          Este aplicativo é distribuído sob licença MIT. Todos os direitos reservados © 2025 PoupeAI.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+};

--- a/src/components/screens/About/styles.ts
+++ b/src/components/screens/About/styles.ts
@@ -1,0 +1,45 @@
+import { StyleSheet } from 'react-native';
+import { colors as themeColors } from '../../../constants/theme';
+
+export const createAboutScreenStyles = (colors: typeof themeColors.theme.light) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  contentContainer: {
+    paddingTop: 16,
+    paddingBottom: 80,
+    paddingHorizontal: 16,
+  },
+  logoText: {
+    color: '#FFFFFF',
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  version: {
+    fontSize: 16,
+  },
+  description: {
+    lineHeight: 22,
+  },
+  developer: {
+    fontSize: 16,
+  },
+  techList: {
+    gap: 4,
+  },
+  techItem: {
+    lineHeight: 20,
+  },
+  license: {
+    lineHeight: 22,
+    fontSize: 14,
+  },
+});

--- a/src/components/screens/Help/index.tsx
+++ b/src/components/screens/Help/index.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Text } from '@/components/atoms/Text';
+import { FAQItem } from '@/components/molecules/FAQItem';
+import { createHelpScreenStyles } from './styles';
+
+export const HelpScreen = () => {
+  const { colors } = useTheme();
+  const styles = createHelpScreenStyles(colors);
+
+  const faqData = [
+    {
+      question: "Como adiciono uma nova transação?",
+      answer: "Para adicionar uma nova transação, vá até a tela principal e toque no botão '+' no canto inferior direito. Preencha os dados da transação como valor, categoria e descrição."
+    },
+    {
+      question: "Como categorizo minhas transações?",
+      answer: "Ao criar uma transação, você pode selecionar uma categoria existente ou criar uma nova. As categorias ajudam a organizar e analisar seus gastos."
+    },
+    {
+      question: "Como funciona o sistema de orçamentos?",
+      answer: "Na aba 'Orçamentos', você pode definir limites de gastos por categoria e período. O app mostrará alertas quando você estiver próximo do limite."
+    },
+    {
+      question: "Posso definir metas financeiras?",
+      answer: "Sim! Na aba 'Metas' você pode criar objetivos financeiros como poupar para uma viagem ou emergência. O app acompanhará seu progresso."
+    },
+    {
+      question: "Como exporto meus dados?",
+      answer: "Vá em Configurações > Exportar dados. Você pode baixar um arquivo com todas suas informações financeiras para backup ou análise externa."
+    },
+    {
+      question: "O app funciona offline?",
+      answer: "Sim, todas as funcionalidades básicas funcionam offline. Os dados são sincronizados quando você tem conexão com a internet."
+    },
+    {
+      question: "Como altero o tema do aplicativo?",
+      answer: "Nas Configurações, você encontra a opção 'Tema' onde pode escolher entre claro, escuro ou seguir o sistema."
+    },
+    {
+      question: "Meus dados estão seguros?",
+      answer: "Sim, utilizamos criptografia de ponta a ponta e autenticação segura via Keycloak. Seus dados financeiros são protegidos seguindo as melhores práticas de segurança."
+    }
+  ];
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <View style={styles.header}>
+        <Text variant="body" color="textSecondary" style={styles.subtitle}>
+          Encontre respostas para as dúvidas mais comuns
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Perguntas Frequentes
+        </Text>
+        
+        <View style={styles.faqContainer}>
+          {faqData.map((item, index) => (
+            <FAQItem
+              key={index}
+              question={item.question}
+              answer={item.answer}
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Precisa de mais ajuda?
+        </Text>
+        
+        <View style={styles.contactCard}>
+          <Ionicons name="mail-outline" size={24} color={colors.textSecondary} />
+          <View style={styles.contactInfo}>
+            <Text variant="subtitle">
+              Entre em contato
+            </Text>
+            <Text variant="body" color="textSecondary">
+              suporte@poupeai.com
+            </Text>
+          </View>
+        </View>
+      </View>
+    </ScrollView>
+  );
+};

--- a/src/components/screens/Help/styles.ts
+++ b/src/components/screens/Help/styles.ts
@@ -1,0 +1,46 @@
+import { StyleSheet } from 'react-native';
+import { colors as themeColors } from '../../../constants/theme';
+
+export const createHelpScreenStyles = (colors: typeof themeColors.theme.light) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  contentContainer: {
+    paddingBottom: 64,
+  },
+  header: {
+    padding: 16,
+    paddingBottom: 24,
+  },
+  subtitle: {
+    lineHeight: 20,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    fontWeight: '600',
+  },
+  faqContainer: {
+    marginHorizontal: 16,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: colors.border,
+    gap: 1
+  },
+  contactCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    padding: 16,
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    gap: 16,
+  },
+  contactInfo: {
+    flex: 1,
+  },
+});

--- a/src/components/screens/Settings/index.tsx
+++ b/src/components/screens/Settings/index.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+import { router } from 'expo-router';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Text } from '@/components/atoms/Text';
+import { SettingsItem } from '@/components/molecules/SettingsItem';
+import { ThemeDropdown } from '@/components/atoms/ThemeDropdown';
+import { createSettingsScreenStyles } from './styles';
+
+export const SettingsScreen = () => {
+  const { colors } = useTheme();
+  const styles = createSettingsScreenStyles(colors);
+
+  const navigateToNotifications = () => {
+    //router.push('/settings/notifications');
+  };
+
+  const navigateToHelp = () => {
+    router.push('/settings/help');
+  };
+
+  const navigateToAbout = () => {
+    router.push('/settings/about');
+  };
+
+  const navigateToExport = () => {
+    // modal to export data
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 88 }}>
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Aparência
+        </Text>
+        <SettingsItem
+          title="Tema"
+          subtitle="Escolha entre claro, escuro ou sistema"
+          icon="color-palette-outline"
+          showChevron={false}
+        >
+          <ThemeDropdown />
+        </SettingsItem>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Preferências
+        </Text>
+        <SettingsItem
+          title="Notificações"
+          subtitle="Gerencie suas notificações"
+          icon="notifications-outline"
+          disabled
+          onPress={navigateToNotifications}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Dados
+        </Text>
+        <SettingsItem
+          title="Exportar dados"
+          subtitle="Baixe uma cópia dos seus dados"
+          icon="download-outline"
+          onPress={navigateToExport}
+        />
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="subtitle" style={styles.sectionTitle}>
+          Suporte
+        </Text>
+        <SettingsItem
+          title="Ajuda e suporte"
+          subtitle="Encontre respostas para suas dúvidas"
+          icon="help-circle-outline"
+          onPress={navigateToHelp}
+        />
+        <SettingsItem
+          title="Sobre o app"
+          subtitle="Versão e informações do aplicativo"
+          icon="information-circle-outline"
+          onPress={navigateToAbout}
+        />
+      </View>
+    </ScrollView>
+  );
+};

--- a/src/components/screens/Settings/styles.ts
+++ b/src/components/screens/Settings/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+import { colors as themeColors } from '../../../constants/theme';
+
+export const createSettingsScreenStyles = (colors: typeof themeColors.theme.light) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  section: {
+    marginTop: 16,
+    gap: 8,
+  },
+  sectionTitle: {
+    marginHorizontal: 16,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+});

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,34 +1,70 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { colors } from '@/constants/theme';
 
 export type ThemeType = 'light' | 'dark';
+export type ThemeMode = 'light' | 'dark' | 'system';
 
 interface ThemeContextData {
   theme: ThemeType;
+  themeMode: ThemeMode;
   colors: typeof colors.theme.light;
   isDark: boolean;
-  toggleTheme: () => void;
+  setThemeMode: (mode: ThemeMode) => void;
+  toggleTheme: () => void; // Mantido para compatibilidade
 }
 
 interface ThemeProviderProps {
   children: ReactNode;
 }
 
+const THEME_STORAGE_KEY = '@poupeai:themeMode';
+
 const ThemeContext = createContext<ThemeContextData>({} as ThemeContextData);
 
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const systemTheme = useColorScheme();
+  const [themeMode, setThemeModeState] = useState<ThemeMode>('system');
   const [theme, setTheme] = useState<ThemeType>(systemTheme || 'light');
 
+  // Carrega o tema salvo no AsyncStorage
   useEffect(() => {
-    if (systemTheme) {
-      setTheme(systemTheme);
-    }
-  }, [systemTheme]);
+    const loadTheme = async () => {
+      try {
+        const savedTheme = await AsyncStorage.getItem(THEME_STORAGE_KEY);
+        if (savedTheme && ['light', 'dark', 'system'].includes(savedTheme)) {
+          setThemeModeState(savedTheme as ThemeMode);
+        }
+      } catch (error) {
+        console.log('Erro ao carregar tema:', error);
+      }
+    };
+    loadTheme();
+  }, []);
 
+  // Atualiza o tema baseado no modo selecionado
+  useEffect(() => {
+    if (themeMode === 'system') {
+      setTheme(systemTheme || 'light');
+    } else {
+      setTheme(themeMode as ThemeType);
+    }
+  }, [themeMode, systemTheme]);
+
+  const setThemeMode = async (mode: ThemeMode) => {
+    try {
+      await AsyncStorage.setItem(THEME_STORAGE_KEY, mode);
+      setThemeModeState(mode);
+    } catch (error) {
+      console.log('Erro ao salvar tema:', error);
+    }
+  };
+
+  // Mantido para compatibilidade (apenas alterna entre light/dark)
   const toggleTheme = () => {
-    setTheme(prev => prev === 'light' ? 'dark' : 'light');
+    const newMode = theme === 'light' ? 'dark' : 'light';
+    setThemeMode(newMode);
   };
 
   const currentColors = colors.theme[theme];
@@ -37,8 +73,10 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
     <ThemeContext.Provider
       value={{
         theme,
+        themeMode,
         colors: currentColors,
         isDark: theme === 'dark',
+        setThemeMode,
         toggleTheme,
       }}
     >


### PR DESCRIPTION
### 📋 **Resumo das Alterações**

Implementação da tela principal de Configurações com navegação por stack para as subtelas About e Help. A tela de Settings foi desenvolvida seguindo o padrão atomic design com lista de opções organizadas, integração completa do sistema de temas (light/dark/system) e navegação estruturada. As telas About e Help foram criadas como páginas estáticas complementares para completar o fluxo de configurações.

---

### 📱 **Tela Principal Criada**

#### **Settings Screen** (Settings)
- Lista de configurações com navegação para subtelas
- Integração do seletor de tema com 3 opções

### 🧱 **Componentes de Apoio Criados**

#### **SettingsItem** (SettingsItem)
- Item reutilizável para lista de configurações
- Suporte a ícones, texto descritivo e navegação

#### **ThemeDropdown** (ThemeDropdown)
- Dropdown customizado para seleção de tema
- Modal com três opções visuais (claro/escuro/sistema)

#### **FAQItem** (FAQItem)
- Componente expansível para FAQ da tela Help
- Estado interno para controle de abertura/fechamento

### 🎨 **Sistema de Tema Aprimorado**

#### **ThemeContext** (ThemeContext.tsx)
- Modo "system" para seguir configuração do dispositivo
- Persistência da preferência no AsyncStorage
- Reatividade automática às mudanças do sistema

### 🗂️ **Navegação Configurada**

#### **Settings Stack** (settings)
- Stack navigator principal: `/settings`
- Subtelas: `/settings/about`, `/settings/help`
- Headers configurados com tema dinâmico