### PR TITLE
Refactor: padroniza propriedades para camelCase, converte `id` para `string` e simplifica retorno de `bank-accounts`

### DIFF
--- a/src/components/atoms/AccountListItem/index.tsx
+++ b/src/components/atoms/AccountListItem/index.tsx
@@ -26,7 +26,7 @@ export const AccountListItem = ({
       return account.description;
     }
     
-    if (account.is_default) {
+    if (account.isDefault) {
       return 'Conta principal para movimentações financeiras';
     }
     
@@ -35,9 +35,9 @@ export const AccountListItem = ({
 
   return (
     <View 
-      style={[style.container, account.is_default && style.defaultContainer]}
+      style={[style.container, account.isDefault && style.defaultContainer]}
     >
-      {account.is_default && (
+      {account.isDefault && (
         <View style={style.defaultHeader}>
           <Text style={style.defaultHeaderText}>PADRÃO</Text>
         </View>
@@ -48,9 +48,9 @@ export const AccountListItem = ({
           <Text style={style.nameText}>{account.name}</Text>
           <Text style={[
             style.balanceText, 
-            account.current_balance < 0 && style.negativeBalance
+            account.currentBalance < 0 && style.negativeBalance
           ]}>
-            {formatCurrencyWithThousands(account.current_balance)}
+            {formatCurrencyWithThousands(account.currentBalance)}
           </Text>
         </View>
 

--- a/src/components/atoms/CurrencyInput/index.tsx
+++ b/src/components/atoms/CurrencyInput/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
+import { View } from "react-native";
 import { FormField } from "@/components/atoms/FormField";
 
 interface CurrencyInputProps {
@@ -20,32 +21,23 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
 }) => {
   const [displayValue, setDisplayValue] = useState("");
 
-  // Função para formatar valor monetário
   const formatCurrency = useCallback(
     (text: string): { formatted: string; numeric: number } => {
-      // Remove tudo que não for dígito
       const onlyDigits = text.replace(/\D/g, "");
 
-      // Se não há dígitos, retorna valores vazios
       if (onlyDigits === "") {
         return { formatted: "", numeric: 0 };
       }
 
-      // Adiciona zeros à esquerda para garantir pelo menos 3 dígitos (para os centavos)
       const paddedDigits = onlyDigits.padStart(3, "0");
-
-      // Separa parte inteira dos centavos
       const integerPart = paddedDigits.slice(0, -2).replace(/^0+/, "") || "0";
       const decimalPart = paddedDigits.slice(-2);
 
-      // Adiciona separadores de milhares
       const formattedInteger = integerPart.replace(
         /\B(?=(\d{3})+(?!\d))/g,
         "."
       );
       const formatted = `R$ ${formattedInteger},${decimalPart}`;
-
-      // Calcula valor numérico
       const numeric = parseFloat(`${integerPart}.${decimalPart}`);
 
       return { formatted, numeric: isNaN(numeric) ? 0 : numeric };
@@ -53,7 +45,6 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
     []
   );
 
-  // Função para converter valor numérico em formato de exibição
   const formatNumericValue = useCallback((numValue: number): string => {
     if (numValue === 0) return "";
 
@@ -66,16 +57,13 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
     return `R$ ${formattedInteger},${decimalPart.toString().padStart(2, "0")}`;
   }, []);
 
-  // Inicializa o displayValue baseado no value prop
   useEffect(() => {
     if (value === "" || value === "0" || value === "0.00") {
       setDisplayValue("");
     } else {
-      // Se value é uma string com formato brasileiro (contém vírgula)
       if (typeof value === "string" && value.includes(",")) {
         setDisplayValue(value.startsWith("R$") ? value : `R$ ${value}`);
       } else {
-        // Se value é um número ou string numérica
         const numericValue =
           typeof value === "string"
             ? parseFloat(value.replace(",", "."))
@@ -91,22 +79,25 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
 
   const handleTextChange = useCallback(
     (text: string) => {
+      if (disabled) return;
       const { formatted, numeric } = formatCurrency(text);
       setDisplayValue(formatted);
       onChangeText(formatted.replace("R$ ", ""), numeric);
     },
-    [formatCurrency, onChangeText]
+    [formatCurrency, onChangeText, disabled]
   );
 
   return (
-    <FormField
-      label={label}
-      placeholder={placeholder}
-      value={displayValue}
-      onChangeText={handleTextChange}
-      keyboardType="numeric"
-      error={error}
-      editable={!disabled}
-    />
+    <View pointerEvents={disabled ? "none" : "auto"} style={{ opacity: disabled ? 0.6 : 1 }}>
+      <FormField
+        label={label}
+        placeholder={placeholder}
+        value={displayValue}
+        onChangeText={handleTextChange}
+        keyboardType="numeric"
+        error={error}
+        editable={!disabled}
+      />
+    </View>
   );
 };

--- a/src/components/molecules/BankAccountModal/index.tsx
+++ b/src/components/molecules/BankAccountModal/index.tsx
@@ -22,6 +22,7 @@ const bankAccountSchema = z.object({
   initial_balance: z
     .number()
     .min(0, "Saldo inicial deve ser maior ou igual a zero"),
+  institution_id: z.number().int().min(1),
   is_default: z.boolean(),
 });
 
@@ -50,6 +51,7 @@ export const BankAccountModal: React.FC<BankAccountModalProps> = ({
     description: "",
     initial_balance: 0,
     is_default: false,
+    institution_id: 1,
   });
 
   const [errors, setErrors] = useState<
@@ -65,9 +67,10 @@ export const BankAccountModal: React.FC<BankAccountModalProps> = ({
         name: account.name,
         description: account.description,
         initial_balance: parseFloat(
-          account.initial_balance.toString().replace(",", ".")
+          account.initialBalance.toString().replace(",", ".")
         ),
-        is_default: account.is_default,
+        is_default: account.isDefault,
+        institution_id: account.institutionId,
       });
     } else {
       setFormData({
@@ -75,6 +78,7 @@ export const BankAccountModal: React.FC<BankAccountModalProps> = ({
         description: "",
         initial_balance: 0,
         is_default: false,
+        institution_id: 1,
       });
     }
     setErrors({});
@@ -110,8 +114,9 @@ export const BankAccountModal: React.FC<BankAccountModalProps> = ({
       const saveData: CreateBankAccountRequest = {
         name: formData.name,
         description: formData.description,
-        initial_balance: formData.initial_balance,
-        is_default: formData.is_default,
+        initialBalance: formData.initial_balance,
+        isDefault: formData.is_default,
+        institutionId: formData.institution_id,
       };
 
       await onSave(saveData);
@@ -188,12 +193,12 @@ export const BankAccountModal: React.FC<BankAccountModalProps> = ({
       <CurrencyInput
         label="Saldo Inicial"
         value={formData.initial_balance.toString()}
-        onChangeText={(formattedValue, numericValue) =>
+        onChangeText={(_, numericValue) =>
           setFormData((prev) => ({ ...prev, initial_balance: numericValue }))
         }
         placeholder="0,00"
         error={errors.initial_balance}
-        disabled={mode === "edit"} // Desabilita edição do saldo inicial no modo de edição
+        disabled={mode === "edit"}
       />
       {mode === "edit" && (
         <Text

--- a/src/components/molecules/TransactionModal/index.tsx
+++ b/src/components/molecules/TransactionModal/index.tsx
@@ -8,13 +8,11 @@ import { ModalContainer } from "@/components/atoms/ModalContainer";
 import { FormField } from "@/components/atoms/FormField";
 import {
   CreateTransactionRequest,
-  Transaction,
   TransactionDetail,
 } from "@/types/transactions";
 import { useBankAccounts } from "@/hooks/useBankAccounts";
 import { TransactionTypeSelector } from "@/components/atoms/TransactionTypeSelector";
 import { CategoryDropdown } from "../CategoryDropdown";
-import { useCategories } from "@/hooks/useCategories";
 import { BankAccountDropDown } from "../BankAccountDropdown";
 import { CreditCardDropDown } from "../CreditCardDropdown";
 import { DatePickerField } from "@/components/atoms/DatePickerField";
@@ -33,7 +31,7 @@ const transactionSchema = z
       })
       .default("BANK_ACCOUNT"),
     category: z.number().int().min(1, "Categoria é obrigatória"),
-    bank_account: z.number().int().optional(),
+    bank_account: z.string().optional(),
     credit_card: z.number().int().optional(),
     is_installment: z.boolean().optional(),
     installment_number: z.number().int().optional(),
@@ -81,8 +79,8 @@ export const TransactionModal: React.FC<TransactionModalProps> = ({
   const [ammountInput, setAmmountInput] = useState<string>("");
 
   const { data: bankAccounts, isLoading: bankLoading } = useBankAccounts();
-  const bankDefault = bankAccounts?.results.find(
-    (account) => account.is_default
+  const bankDefault = bankAccounts?.find(
+    (account) => account.isDefault
   );
 
   const [categoriesIsOpen, setCategoriesIsOpen] = useState(false);

--- a/src/components/screens/AccountsList/index.tsx
+++ b/src/components/screens/AccountsList/index.tsx
@@ -193,7 +193,7 @@ export const AccountsList = () => {
         </View>
 
         <FlatList
-          data={bankAccountsData?.results || []}
+          data={bankAccountsData || []}
           keyExtractor={(item) => item.id.toString()}
           renderItem={renderAccountItem}
           showsVerticalScrollIndicator={false}

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -21,10 +21,10 @@ export const invoicesKeys = {
 export const bankAccountsKeys = {
   all: ["bank-accounts"] as const,
   lists: () => [...bankAccountsKeys.all, "list"] as const,
-  list: (filters: Record<string, any>) =>
-    [...bankAccountsKeys.lists(), { filters }] as const,
+  list: () =>
+    [...bankAccountsKeys.lists()] as const,
   details: () => [...bankAccountsKeys.all, "detail"] as const,
-  detail: (id: number) => [...bankAccountsKeys.details(), id] as const,
+  detail: (id: string) => [...bankAccountsKeys.details(), id] as const,
 };
 
 export const creditCardsKeys = {

--- a/src/hooks/useBankAccounts.ts
+++ b/src/hooks/useBankAccounts.ts
@@ -11,21 +11,17 @@ import {
 } from "@/constants/queryKeys";
 import { useAuth } from "@/contexts/AuthContext";
 
-export function useBankAccounts(params?: {
-  search?: string;
-  page?: number;
-  page_size?: number;
-}) {
+export function useBankAccounts() {
   const { isAuthenticated, user } = useAuth();
 
   return useQuery({
-    queryKey: bankAccountsKeys.list(params || {}),
-    queryFn: () => bankAccountsService.getBankAccounts(params),
-    enabled: isAuthenticated && !!user, // Só executa se o usuário estiver autenticado
+    queryKey: bankAccountsKeys.list(),
+    queryFn: () => bankAccountsService.getBankAccounts(),
+    enabled: isAuthenticated && !!user,
   });
 }
 
-export function useBankAccount(id: number, enabled = true) {
+export function useBankAccount(id: string, enabled = true) {
   if (!id) {
     return {
       data: null,
@@ -79,7 +75,7 @@ export function useDeleteBankAccount() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: number) => bankAccountsService.deleteBankAccount(id),
+    mutationFn: (id: string) => bankAccountsService.deleteBankAccount(id),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: bankAccountsKeys.lists(),

--- a/src/services/bankAccounts.ts
+++ b/src/services/bankAccounts.ts
@@ -1,24 +1,20 @@
 import { api } from './api';
-import { Account, BankAccountsResponse, CreateBankAccountRequest } from '../types/accounts';
+import { Account, CreateBankAccountRequest } from '@/types/accounts';
 
 export interface UpdateBankAccountRequest extends Partial<CreateBankAccountRequest> {
-  id: number;
+  id: string;
 }
 
 export class BankAccountsService {
-  private baseUrl = 'finances/api/v1/bank-accounts/';
+  private baseUrl = 'core/api/v1/bank-accounts';
 
-  async getBankAccounts(params?: {
-    search?: string;
-    page?: number;
-    page_size?: number;
-  }): Promise<BankAccountsResponse> {
-    const response = await api.get(this.baseUrl, { params });
+  async getBankAccounts(): Promise<Account[]> {
+    const response = await api.get(this.baseUrl);
     return response.data;
   }
 
-  async getBankAccountById(id: number): Promise<Account> {
-    const response = await api.get<Account>(`${this.baseUrl}${id}/`);
+  async getBankAccountById(id: string): Promise<Account> {
+    const response = await api.get<Account>(`${this.baseUrl}/${id}`);
     return response.data;
   }
 
@@ -29,12 +25,12 @@ export class BankAccountsService {
 
   async updateBankAccount(data: UpdateBankAccountRequest): Promise<Account> {
     const { id, ...updateData } = data;
-    const response = await api.patch<Account>(`${this.baseUrl}${id}/`, updateData);
+    const response = await api.patch<Account>(`${this.baseUrl}/${id}`, updateData);
     return response.data;
   }
 
-  async deleteBankAccount(id: number): Promise<void> {
-    await api.delete(`${this.baseUrl}${id}/`);
+  async deleteBankAccount(id: string): Promise<void> {
+    await api.delete(`${this.baseUrl}/${id}`);
   }
 }
 

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -1,24 +1,19 @@
 export interface Account {
-  id: number;
+  id: string;
   name: string;
   description: string;
-  initial_balance: string;
-  current_balance: number;
-  is_default: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface BankAccountsResponse {
-  results: Account[];
-  count: number;
-  next: string | null;
-  previous: string | null;
+  initialBalance: number;
+  currentBalance: number;
+  isDefault: boolean;
+  institutionId: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface CreateBankAccountRequest {
   name: string;
   description: string;
-  initial_balance: number;
-  is_default: boolean;
+  initialBalance: number;
+  isDefault: boolean;
+  institutionId: number;
 }


### PR DESCRIPTION
## Descrição
Refatoração que altera a forma dos dados de contas e transações para usar propriedades em camelCase, muda `id` para `string` e adapta o serviço `/bank-accounts` para retornar um array simples (remove paginação). Atualiza tipos, serviços, hooks, query keys e componentes para a nova shape.

---

## Alterações principais
- Tipos
  - accounts.ts: propriedades renomeadas para camelCase (`initialBalance`, `currentBalance`, `isDefault`, `institutionId`, `createdAt`, `updatedAt`) e `id: string`. `CreateBankAccountRequest` atualizado.
- Serviço
  - bankAccounts.ts: `baseUrl` alterado para `core/api/v1/bank-accounts`; `getBankAccounts()` passa a retornar `Account[]`; endpoints GET/PATCH/DELETE usam `/${id}` (aceitando `string`).
- Hooks / Query keys
  - useBankAccounts.ts: remoção de params, `queryKey` simplificado; `useBankAccount` e deleção aceitam `string` id.
  - queryKeys.ts: `list()` sem filtros; `detail(id: string)`.
- Componentes / UI
  - Ajustes em vários componentes para usar camelCase (ex.: `AccountListItem`, `BankAccountModal`, `TransactionModal`, `AccountsList`).
  - `CurrencyInput`: wrapper `View` com `pointerEvents`/opacidade para `disabled` e melhorias menores.
- Código de utilização
  - Adaptação de locais que esperavam `results` paginados para trabalhar com arrays simples.
